### PR TITLE
Fix inversePatches applying order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@legalscape/mutative",
-  "version": "1.0.8-ls.55ad523",
+  "version": "1.0.8-ls.3af40b9",
   "description": "A JavaScript library for efficient immutable updates",
   "main": "dist/index.js",
   "module": "dist/mutative.esm.js",

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -15,11 +15,14 @@ const ADDED = Symbol('ADDED');
 function generateArrayPatches(
   proxyState: ProxyDraft<Array<any>>,
   basePath: any[],
-  patches: Patches,
-  inversePatches: Patches,
+  patches_: Patches,
+  inversePatches_: Patches,
   pathAsArray: boolean
 ) {
   let { original, arrayChanges } = proxyState;
+
+  const patches = [];
+  const inversePatches = [];
 
   // console.log('generateArrayPatches', proxyState.key);
 
@@ -137,6 +140,9 @@ function generateArrayPatches(
       path: escapePath(basePath.concat([original.length]), pathAsArray),
     });
   }
+
+  patches_.push(...patches);
+  inversePatches_.unshift(...inversePatches);
 
   // console.log('patches', [...patches]);
   // console.log('inversePatches', [...inversePatches]);

--- a/test/__snapshots__/apply.test.ts.snap
+++ b/test/__snapshots__/apply.test.ts.snap
@@ -98,14 +98,6 @@ exports[`#468 2`] = `
     "op": "replace",
     "path": [
       0,
-      "id",
-    ],
-    "value": 1,
-  },
-  {
-    "op": "replace",
-    "path": [
-      0,
     ],
     "value": {
       "id": 1,
@@ -116,6 +108,14 @@ exports[`#468 2`] = `
     "path": [
       1,
     ],
+  },
+  {
+    "op": "replace",
+    "path": [
+      0,
+      "id",
+    ],
+    "value": 1,
   },
 ]
 `;
@@ -473,161 +473,31 @@ exports[`array 4`] = `
   {
     "op": "replace",
     "path": [
-      "arr10",
-      1,
-    ],
-    "value": 2,
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr9",
-      3,
-    ],
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr8",
-      0,
-    ],
-    "value": 1,
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr8",
-      1,
-    ],
-    "value": 2,
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr8",
+      "arr",
       2,
     ],
     "value": 3,
   },
   {
-    "op": "replace",
-    "path": [
-      "arr7",
-      0,
-    ],
-    "value": 2,
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr7",
-      1,
-    ],
-    "value": 1,
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr6",
-      0,
-    ],
-    "value": "a",
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr6",
-      2,
-    ],
-    "value": "c",
-  },
-  {
-    "op": "add",
-    "path": [
-      "arr5",
-      0,
-    ],
-    "value": "a",
-  },
-  {
     "op": "remove",
     "path": [
-      "arr4",
-      0,
-    ],
-  },
-  {
-    "op": "add",
-    "path": [
-      "arr3",
-      2,
-    ],
-    "value": "c",
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr2",
+      "arr",
       3,
     ],
   },
   {
-    "op": "replace",
+    "op": "remove",
     "path": [
-      "arr1",
-      0,
-      "a",
+      "arr",
+      3,
     ],
-    "value": 1,
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr",
+      3,
+    ],
   },
   {
     "op": "replace",
@@ -647,9 +517,87 @@ exports[`array 4`] = `
     ],
   },
   {
+    "op": "remove",
+    "path": [
+      "arr2",
+      3,
+    ],
+  },
+  {
+    "op": "add",
+    "path": [
+      "arr3",
+      2,
+    ],
+    "value": "c",
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr4",
+      0,
+    ],
+  },
+  {
+    "op": "add",
+    "path": [
+      "arr5",
+      0,
+    ],
+    "value": "a",
+  },
+  {
     "op": "replace",
     "path": [
-      "arr",
+      "arr6",
+      0,
+    ],
+    "value": "a",
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr6",
+      2,
+    ],
+    "value": "c",
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr7",
+      0,
+    ],
+    "value": 2,
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr7",
+      1,
+    ],
+    "value": 1,
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr8",
+      0,
+    ],
+    "value": 1,
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr8",
+      1,
+    ],
+    "value": 2,
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr8",
       2,
     ],
     "value": 3,
@@ -657,23 +605,75 @@ exports[`array 4`] = `
   {
     "op": "remove",
     "path": [
-      "arr",
+      "arr9",
       3,
     ],
   },
   {
     "op": "remove",
     "path": [
-      "arr",
+      "arr9",
       3,
     ],
   },
   {
     "op": "remove",
     "path": [
-      "arr",
+      "arr9",
       3,
     ],
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr9",
+      3,
+    ],
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr9",
+      3,
+    ],
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr9",
+      3,
+    ],
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr9",
+      3,
+    ],
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr9",
+      3,
+    ],
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr10",
+      1,
+    ],
+    "value": 2,
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr1",
+      0,
+      "a",
+    ],
+    "value": 1,
   },
 ]
 `;
@@ -734,29 +734,16 @@ exports[`array 5`] = `
 exports[`array 6`] = `
 [
   {
-    "op": "replace",
+    "op": "remove",
     "path": [
-      "arr4",
+      "arr0",
       0,
     ],
-    "value": {
-      "bar": "str1",
-    },
   },
   {
-    "op": "replace",
+    "op": "add",
     "path": [
-      "arr4",
-      1,
-    ],
-    "value": {
-      "bar": "str1",
-    },
-  },
-  {
-    "op": "replace",
-    "path": [
-      "arr3",
+      "arr2",
       1,
     ],
     "value": {
@@ -774,9 +761,9 @@ exports[`array 6`] = `
     },
   },
   {
-    "op": "add",
+    "op": "replace",
     "path": [
-      "arr2",
+      "arr3",
       1,
     ],
     "value": {
@@ -784,11 +771,24 @@ exports[`array 6`] = `
     },
   },
   {
-    "op": "remove",
+    "op": "replace",
     "path": [
-      "arr0",
+      "arr4",
       0,
     ],
+    "value": {
+      "bar": "str1",
+    },
+  },
+  {
+    "op": "replace",
+    "path": [
+      "arr4",
+      1,
+    ],
+    "value": {
+      "bar": "str1",
+    },
   },
 ]
 `;
@@ -818,12 +818,6 @@ exports[`array length with ref 1`] = `
 exports[`array length with ref 2`] = `
 [
   {
-    "op": "remove",
-    "path": [
-      "f",
-    ],
-  },
-  {
     "op": "replace",
     "path": [
       "foobar",
@@ -832,6 +826,12 @@ exports[`array length with ref 2`] = `
     "value": {
       "baz": "str",
     },
+  },
+  {
+    "op": "remove",
+    "path": [
+      "f",
+    ],
   },
 ]
 `;
@@ -860,12 +860,6 @@ exports[`array pop with ref 1`] = `
 exports[`array pop with ref 2`] = `
 [
   {
-    "op": "remove",
-    "path": [
-      "f",
-    ],
-  },
-  {
     "op": "add",
     "path": [
       "foobar",
@@ -874,6 +868,12 @@ exports[`array pop with ref 2`] = `
     "value": {
       "baz": "str",
     },
+  },
+  {
+    "op": "remove",
+    "path": [
+      "f",
+    ],
   },
 ]
 `;
@@ -947,12 +947,6 @@ exports[`array shift with ref 1`] = `
 exports[`array shift with ref 2`] = `
 [
   {
-    "op": "remove",
-    "path": [
-      "f",
-    ],
-  },
-  {
     "op": "add",
     "path": [
       "foobar",
@@ -961,6 +955,12 @@ exports[`array shift with ref 2`] = `
     "value": {
       "baz": "str",
     },
+  },
+  {
+    "op": "remove",
+    "path": [
+      "f",
+    ],
   },
 ]
 `;
@@ -989,12 +989,6 @@ exports[`array splice with ref 1`] = `
 exports[`array splice with ref 2`] = `
 [
   {
-    "op": "remove",
-    "path": [
-      "f",
-    ],
-  },
-  {
     "op": "add",
     "path": [
       "foobar",
@@ -1003,6 +997,12 @@ exports[`array splice with ref 2`] = `
     "value": {
       "baz": "str",
     },
+  },
+  {
+    "op": "remove",
+    "path": [
+      "f",
+    ],
   },
 ]
 `;
@@ -1039,6 +1039,16 @@ exports[`array with ref 1`] = `
 exports[`array with ref 2`] = `
 [
   {
+    "op": "add",
+    "path": [
+      "foobar",
+      0,
+    ],
+    "value": {
+      "baz": "str",
+    },
+  },
+  {
     "op": "replace",
     "path": [
       "f",
@@ -1051,16 +1061,6 @@ exports[`array with ref 2`] = `
     "path": [
       "foobar1",
     ],
-  },
-  {
-    "op": "add",
-    "path": [
-      "foobar",
-      0,
-    ],
-    "value": {
-      "baz": "str",
-    },
   },
 ]
 `;
@@ -2060,6 +2060,20 @@ exports[`enablePatches and assign with ref array 1`] = `
 exports[`enablePatches and assign with ref array 2`] = `
 [
   {
+    "op": "remove",
+    "path": [
+      "arr0",
+      1,
+    ],
+  },
+  {
+    "op": "remove",
+    "path": [
+      "arr0",
+      1,
+    ],
+  },
+  {
     "op": "replace",
     "path": [
       "arr1",
@@ -2067,20 +2081,6 @@ exports[`enablePatches and assign with ref array 2`] = `
       "a",
     ],
     "value": 1,
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr0",
-      1,
-    ],
-  },
-  {
-    "op": "remove",
-    "path": [
-      "arr0",
-      1,
-    ],
   },
   {
     "op": "add",

--- a/test/json-patch.test.ts
+++ b/test/json-patch.test.ts
@@ -1698,4 +1698,72 @@ describe('length change tracking', () => {
       });
     });
   });
+
+  test('inversePatches order', () => {
+    const numbers = [0, 1, 2, 3];
+    const objects = numbers.map((id) => ({ id }));
+
+    const [forward, backward] = test_(objects, (draft) => {
+      draft[3].id *= 10;
+      draft.splice(0, 1);
+    });
+
+    expect(forward).toMatchInlineSnapshot(`
+      [
+        {
+          "op": "replace",
+          "path": [
+            3,
+            "id",
+          ],
+          "value": 30,
+        },
+        {
+          "op": "remove",
+          "path": [
+            0,
+          ],
+        },
+        {
+          "op": "replace",
+          "path": [
+            2,
+          ],
+          "value": {
+            "id": 30,
+          },
+        },
+      ]
+    `);
+    expect(backward).toMatchInlineSnapshot(`
+      [
+        {
+          "op": "add",
+          "path": [
+            0,
+          ],
+          "value": {
+            "id": 0,
+          },
+        },
+        {
+          "op": "replace",
+          "path": [
+            3,
+          ],
+          "value": {
+            "id": 3,
+          },
+        },
+        {
+          "op": "replace",
+          "path": [
+            3,
+            "id",
+          ],
+          "value": 3,
+        },
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
（本家でも再現するので近いうちにissueを送る予定）

以下のように、「オブジェクト内部に変更 → （手前の要素を削除するなどして）そのオブジェクトのインデックスを変更」した場合、

https://github.com/legalscape/mutative/blob/3af40b93cb076a491684730cc5cfa7eb3fe5a31e/test/json-patch.test.ts#L1707-L1708

以下のようにinversePatchesが存在しない要素を参照（replace）してしまいapply時にエラーとなる。

```
prevState: [0, 1, 2, 3]
nextState: [1, 2, 30]

patches:
1. replace arr[3]
2. remove arr[0]

inversePatches:
1. replace arr[3] <- 存在せずエラー
2. add arr[0]
```

この問題の修正のため、inversePatchesへの（配列に関する）パッチの追加をunshiftすることで対応する。